### PR TITLE
feat(front): 各API呼び出しに認証トークン付与 (3.1)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -14,6 +14,8 @@ module.exports = {
     ...appJson.expo,
     extra: {
       apiUrl: process.env.EXPO_PUBLIC_API_URL || '',
+      supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL || '',
+      supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY || '',
     },
   },
 };

--- a/src/features/auth/authStore.ts
+++ b/src/features/auth/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { supabase } from '@shared/lib';
 
 /**
  * ユーザー情報の型定義
@@ -26,12 +27,12 @@ interface AuthActions {
   setUser: (user: User | null) => void;
   setLoading: (isLoading: boolean) => void;
   setError: (error: string | null) => void;
-  logout: () => void;
+  logout: () => void | Promise<void>;
 }
 
 /**
  * 認証ストア（Zustand）
- * ユーザーの認証状態を管理
+ * ユーザーの認証状態を管理。ログアウト時に Supabase のセッションも破棄する。
  */
 export const useAuthStore = create<AuthState & AuthActions>(set => ({
   // State
@@ -52,10 +53,14 @@ export const useAuthStore = create<AuthState & AuthActions>(set => ({
 
   setError: error => set({ error, isLoading: false }),
 
-  logout: () =>
+  logout: async () => {
+    if (supabase) {
+      await supabase.auth.signOut();
+    }
     set({
       user: null,
       isAuthenticated: false,
       error: null,
-    }),
+    });
+  },
 }));

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1,0 +1,92 @@
+/**
+ * 認証付き共通 API クライアント
+ *
+ * 自前バックエンド（FastAPI）へのリクエストに Authorization ヘッダーを付与する。
+ * トークンは Supabase Auth のセッションから取得し、必要ならリフレッシュしてから付与する。
+ *
+ * 使用例:
+ *   const res = await authenticatedFetch('/api/v1/settings');
+ *   const res = await authenticatedFetch('/api/v1/sleep-plans', { method: 'POST', body: JSON.stringify(data) });
+ */
+
+import Constants from 'expo-constants';
+import { supabase } from './supabase';
+
+const DEFAULT_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
+};
+
+export type AuthenticatedFetchOptions = Omit<RequestInit, 'headers'> & {
+  headers?: Record<string, string> | Headers;
+  /** true のときはトークンがなくても Authorization を付けずにリクエストする（未認証で 401 になる） */
+  skipAuth?: boolean;
+};
+
+/**
+ * 現在のアクセストークンを取得する。期限切れの場合はリフレッシュしてから返す。
+ * Supabase 未設定または未ログインの場合は null。
+ */
+export async function getAccessToken(): Promise<string | null> {
+  if (!supabase) return null;
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession();
+  if (sessionError || !session) return null;
+  const expiresAt = session.expires_at;
+  const now = Math.floor(Date.now() / 1000);
+  const bufferSeconds = 60;
+  if (expiresAt != null && expiresAt < now + bufferSeconds) {
+    const { data: refreshed, error: refreshError } =
+      await supabase.auth.refreshSession();
+    if (refreshError || !refreshed.session) return null;
+    return refreshed.session.access_token;
+  }
+  return session.access_token;
+}
+
+/**
+ * 認証トークン付きで fetch する。
+ * - Supabase が設定されていてセッションがあれば Authorization: Bearer <token> を付与する。
+ * - トークンが期限切れの場合はリフレッシュしてから付与する。
+ * - skipAuth: true のときはトークンを付けない。
+ */
+export async function authenticatedFetch(
+  url: string,
+  options: AuthenticatedFetchOptions = {}
+): Promise<Response> {
+  const { skipAuth = false, headers: customHeaders, ...rest } = options;
+  const headers = new Headers(DEFAULT_HEADERS);
+  if (customHeaders) {
+    const h = customHeaders instanceof Headers ? customHeaders : new Headers(customHeaders);
+    h.forEach((value, key) => headers.set(key, value));
+  }
+  if (!skipAuth) {
+    const token = await getAccessToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(url, { ...rest, headers });
+}
+
+/**
+ * バックエンド API のベース URL（末尾の /api/v1 は含めない。例: http://192.168.x.x:8000）
+ */
+export function getApiBaseUrl(): string {
+  const extra = (Constants.expoConfig?.extra ?? {}) as { apiUrl?: string };
+  const base = (extra.apiUrl ?? '').trim();
+  return base ? base.replace(/\/$/, '') : 'http://localhost:8000';
+}
+
+/**
+ * 認証付きでバックエンドの /api/v1 へのフル URL を取得して fetch する。
+ * path は /api/v1 からの相対（先頭スラッシュあり: '/settings'）またはスラッシュなし（'settings'）で指定。
+ */
+export async function apiV1Fetch(
+  path: string,
+  options: AuthenticatedFetchOptions = {}
+): Promise<Response> {
+  const base = getApiBaseUrl();
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const url = `${base}/api/v1${normalizedPath}`;
+  return authenticatedFetch(url, options);
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,6 +1,15 @@
 /**
  * Shared Libraries - Public API
  */
+export { supabase, isSupabaseConfigured } from './supabase';
+export {
+  authenticatedFetch,
+  apiV1Fetch,
+  getAccessToken,
+  getApiBaseUrl,
+} from './apiClient';
+export type { AuthenticatedFetchOptions } from './apiClient';
+
 export { llmClient } from './llm';
 export type { LLMConfig, ChatMessage, ChatResponse } from './llm';
 

--- a/src/shared/lib/supabase.ts
+++ b/src/shared/lib/supabase.ts
@@ -1,0 +1,41 @@
+/**
+ * Supabase クライアント（認証・セッション永続化）
+ *
+ * セッションは AsyncStorage に保存し、アプリ再起動後も維持する。
+ * トークンは Supabase Auth から取得し、自前 API の Authorization ヘッダーに付与する。
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
+
+const extra = (Constants.expoConfig?.extra ?? {}) as {
+  supabaseUrl?: string;
+  supabaseAnonKey?: string;
+};
+const supabaseUrl = (extra.supabaseUrl ?? '').trim();
+const supabaseAnonKey = (extra.supabaseAnonKey ?? '').trim();
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn(
+    '[supabase] EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY is missing. Auth will not work until .env.expo.local is set (e.g. task dev-up).'
+  );
+}
+
+let _client: SupabaseClient | null = null;
+if (supabaseUrl && supabaseAnonKey) {
+  _client = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      storage: AsyncStorage,
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: false,
+    },
+  });
+}
+
+export const supabase: SupabaseClient | null = _client;
+
+/** Supabase が有効に設定されているか */
+export const isSupabaseConfigured = (): boolean => supabase !== null;


### PR DESCRIPTION
## 目的
各 API 呼び出しに認証トークンを付与する。

## 成果物
- **共通 HTTP クライアント** (`apiClient.ts`) で `Authorization: Bearer <token>` を付与
- トークンは **Supabase Auth** から取得・リフレッシュ（`getSession` / `refreshSession`）
- `apiV1Fetch(path, options)` で `/api/v1` への認証付きリクエストを共通化
- 睡眠プラン API (`sleepPlanApi.ts`) で `apiV1Fetch` を使用
- ログイン画面を Supabase `signInWithPassword` 連携に変更、ログアウトで `signOut`

## 参照
- docs/backend-design.md §2, §9
- docs/implementation-plan.md 3.1

Made with [Cursor](https://cursor.com)