### PR TITLE
feat: 認証トークン付与・ログイン/サインアップ・エミュレータ接続対策

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,6 +46,23 @@ tasks:
     cmds:
       - pnpm supabase stop
 
+  # Metro / Expo バンドラーを停止（ポート 8081 使用プロセスを終了。dev-up-emulator 前に実行すると .env が確実に読み直される）
+  metro-stop:
+    desc: Metro / Expo のバンドラーを停止（ポート 8081）
+    cmds:
+      - |
+        if command -v lsof >/dev/null 2>&1; then
+          PIDS=$(lsof -ti:8081 2>/dev/null) || true
+          if [ -n "$PIDS" ]; then
+            echo "Metro (port 8081) を停止します: $PIDS"
+            echo "$PIDS" | xargs kill -9 2>/dev/null || true
+          else
+            echo "ポート 8081 で動作中のプロセスはありません。"
+          fi
+        else
+          echo "lsof が見つかりません。手動で Metro/Expo を終了してください。"
+        fi
+
   # 開発環境をまとめて起動（Expo は含まない。別ターミナルで task expo-start）
   # 注意: "container name already in use" が出たら docker rm -f sleepsupport-db sleepsupport-api してから再実行
 
@@ -90,6 +107,7 @@ tasks:
   # エミュレータ用: EXPO_PUBLIC_API_URL を 10.0.2.2 に固定（Android エミュレータからホスト PC へ接続）
   # 環境構築ののち Android Development Build をビルド＆起動。エミュレータを起動してから実行すること。
   # 毎回 DB をゼロから構築するため、docker-compose down -v でボリューム削除してから up
+  # Network request failed になる場合は docs/troubleshooting-emulator-network.md を参照（Metro を止めてから実行すること）
   dev-up-emulator:
     desc: エミュレータ用 - 環境構築（10.0.2.2）＋ .env.expo.local 更新 ＋ Android ビルド＆起動
     cmds:
@@ -104,8 +122,9 @@ tasks:
       - EXPO_PUBLIC_API_URL=http://10.0.2.2:8000 node scripts/write-expo-env.mjs
       - |
         echo ""
-        echo "[エミュレータ用] API: http://10.0.2.2:${API_PORT:-8000}  Supabase Studio: http://127.0.0.1:54323"
+        echo "[エミュレータ用] API: http://10.0.2.2:${API_PORT:-8000}  Supabase: http://10.0.2.2:54321"
         echo "Android ビルド＆起動します（エミュレータを起動済みにしてください）。"
+        echo "Network request failed のときは Metro を止めてから再実行するか、docs/troubleshooting-emulator-network.md を参照。"
       - |
         export JAVA_HOME=$(/usr/libexec/java_home -v 17 2>/dev/null) || true
         npx expo run:android

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,0 +1,18 @@
+import { Stack } from 'expo-router';
+
+/**
+ * 認証フロー用レイアウト（ログイン・サインアップ）
+ */
+export default function AuthLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: '#1E293B' },
+      }}
+    >
+      <Stack.Screen name="login" />
+      <Stack.Screen name="signup" />
+    </Stack>
+  );
+}

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { LoginScreen } from '@features/auth';
+import { supabase } from '@shared/lib';
+import { useAuthStore } from '@features/auth/authStore';
+
+/**
+ * ログインルート
+ * 既にセッションがあればタブへリダイレクト、なければログイン画面を表示
+ */
+export default function LoginRoute() {
+  const router = useRouter();
+  const setUser = useAuthStore(s => s.setUser);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!supabase) return;
+      const { data: { session } } = await supabase.auth.getSession();
+      if (cancelled || !session?.user) return;
+      setUser({
+        id: session.user.id,
+        email: session.user.email ?? '',
+        name: session.user.user_metadata?.name ?? session.user.email ?? undefined,
+      });
+      router.replace('/(tabs)');
+    })();
+    return () => { cancelled = true; };
+  }, [router, setUser]);
+
+  const handleLoginSuccess = () => {
+    router.replace('/(tabs)');
+  };
+
+  const handleNavigateToSignup = () => {
+    router.push('/(auth)/signup');
+  };
+
+  return (
+    <LoginScreen
+      onLoginSuccess={handleLoginSuccess}
+      onNavigateToSignup={handleNavigateToSignup}
+    />
+  );
+}

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,0 +1,24 @@
+import { useRouter } from 'expo-router';
+import { SignupScreen } from '@features/auth';
+
+/**
+ * サインアップルート
+ */
+export default function SignupRoute() {
+  const router = useRouter();
+
+  const handleSignupSuccess = () => {
+    router.replace('/(tabs)');
+  };
+
+  const handleNavigateToLogin = () => {
+    router.back();
+  };
+
+  return (
+    <SignupScreen
+      onSignupSuccess={handleSignupSuccess}
+      onNavigateToLogin={handleNavigateToLogin}
+    />
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,7 +19,9 @@ export default function RootLayout() {
           headerShown: false,
           contentStyle: { backgroundColor: '#1E293B' },
         }}
+        initialRouteName="(auth)"
       >
+        <Stack.Screen name="(auth)" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       </Stack>
 

--- a/docs/troubleshooting-emulator-network.md
+++ b/docs/troubleshooting-emulator-network.md
@@ -1,0 +1,93 @@
+# エミュレータで「Network request failed」になる場合
+
+## 想定される原因
+
+### 1. 設定がビルド／Metro に反映されていない（最も多い）
+
+- **Expo の `extra`（apiUrl, supabaseUrl）は Metro 起動時に `app.config.js` から読み込まれる。**
+- すでに Metro が動いている状態で `write-expo-env.mjs` だけ実行すると、**既存の Metro は古い .env を保持したまま**になる。
+- その結果、アプリは 127.0.0.1 のままの URL でリクエストし、エミュレータから届かず「Network request failed」になる。
+
+### 2. エミュレータからホストへの接続先
+
+- エミュレータ内の `127.0.0.1` は**エミュレータ自身**を指す。ホストの Supabase/API には届かない。
+- ホストへは **`10.0.2.2`** を使う必要がある（Android の仕様）。
+- `task dev-up-emulator` は `.env.expo.local` に API / Supabase ともに `10.0.2.2` を書き込む。
+
+### 3. HTTP (cleartext) がブロックされている
+
+- Android 9 以降はデフォルトで HTTP を許可しない。
+- このプロジェクトでは `app.json` の `expo-build-properties` で `usesCleartextTraffic: true` を指定済み。**別タスクでビルドした apk を使っている場合は、そのビルドにも同じ設定が入っているか確認する。**
+
+### 4. Supabase / API がホストで動いていない
+
+- エミュレータは `10.0.2.2` でホストに届くが、**ホスト側で Supabase と API が起動している必要がある。**
+- `task dev-up-emulator` は Supabase 起動 → docker-compose → write-expo-env → expo run:android の順で実行する。
+
+---
+
+## 対処手順
+
+### 手順 A: Metro を止めてからやり直す（まず試す）
+
+1. **Metro / Expo をすべて終了する**（別ターミナルで `expo start` や `npx expo run:android` を実行していた場合は Ctrl+C）。
+2. 以下を**この順で**実行する。
+
+   ```bash
+   task dev-up-emulator
+   ```
+
+3. これで「write-expo-env → expo run:android」の順になり、**新しい Metro が最新の .env.expo.local を読む**。
+
+### 手順 B: キャッシュを消してからビルドし直す
+
+1. Metro を止める。
+2. キャッシュを消してからエミュレータ用に書き直し・ビルドする。
+
+   ```bash
+   EXPO_PUBLIC_API_URL=http://10.0.2.2:8000 node scripts/write-expo-env.mjs
+   npx expo start --clear
+   ```
+
+3. 別ターミナルでエミュレータを起動し、表示された QR または「Run on Android device/emulator」で起動する。  
+   または、Metro を止めたうえで以下でビルド＆起動する。
+
+   ```bash
+   EXPO_PUBLIC_API_URL=http://10.0.2.2:8000 node scripts/write-expo-env.mjs
+   npx expo run:android
+   ```
+
+### 手順 C: ネイティブをクリーンしてからやり直す
+
+`extra` がネイティブ側に古く残っている可能性がある場合:
+
+1. Metro を止める。
+2. `android` フォルダを削除する（存在する場合）。
+
+   ```bash
+   rm -rf android
+   ```
+
+3. エミュレータ用に .env を書き、prebuild からやり直す。
+
+   ```bash
+   EXPO_PUBLIC_API_URL=http://10.0.2.2:8000 node scripts/write-expo-env.mjs
+   npx expo prebuild --clean
+   npx expo run:android
+   ```
+
+   （Supabase と docker-compose は別途 `task supabase-start` と `docker-compose up -d` で起動しておく。）
+
+### 手順 D: 実際に使われている URL を確認する
+
+- アプリ起動後、ログイン画面などで Supabase にリクエストが飛ぶタイミングで、**Metro のターミナル**や **Logcat** に  
+  `[supabase] using url: http://...` のようなログが出る（開発時のみ。`src/shared/lib/supabase.ts` で出力）。
+- ここが `http://10.0.2.2:54321` になっていればエミュレータ用の設定は反映されている。  
+  `127.0.0.1` のままなら、上記 A〜C のいずれかで「Metro / ビルドのやり直し」が必要。
+
+---
+
+## まとめ
+
+- **「Network request failed」の多くは、Metro が古い .env のまま動いているか、ネイティブに古い extra が残っていることが原因。**
+- **Metro を止めてから `task dev-up-emulator` を最初から実行する**か、**手順 B/C でキャッシュ／ネイティブをクリーンしてからビルドし直す**と解消することが多い。

--- a/src/features/auth/LoginScreen.tsx
+++ b/src/features/auth/LoginScreen.tsx
@@ -13,12 +13,22 @@ import { COLORS } from '@shared/constants';
 import { supabase, isSupabaseConfigured } from '@shared/lib';
 import { useAuthStore } from './authStore';
 
+export interface LoginScreenProps {
+  /** ログイン成功時（セッション取得済み） */
+  onLoginSuccess?: () => void;
+  /** 「アカウントを作成」でサインアップへ */
+  onNavigateToSignup?: () => void;
+}
+
 /**
  * ログイン画面
  * Supabase Auth でメール/パスワード認証を行い、セッションを取得する。
  * 取得したトークンは apiClient 経由の API 呼び出しで自動付与される。
  */
-export const LoginScreen: React.FC = () => {
+export const LoginScreen: React.FC<LoginScreenProps> = ({
+  onLoginSuccess,
+  onNavigateToSignup,
+}) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const { setUser, setLoading, setError, isLoading, error } = useAuthStore();
@@ -49,6 +59,7 @@ export const LoginScreen: React.FC = () => {
         email: user.email ?? '',
         name: user.user_metadata?.name ?? user.email ?? undefined,
       });
+      onLoginSuccess?.();
     } finally {
       setLoading(false);
     }
@@ -104,6 +115,16 @@ export const LoginScreen: React.FC = () => {
           >
             <Text style={styles.buttonText}>{isLoading ? 'ログイン中...' : 'ログイン'}</Text>
           </TouchableOpacity>
+
+          {onNavigateToSignup && (
+            <TouchableOpacity
+              style={styles.linkButton}
+              onPress={onNavigateToSignup}
+              disabled={isLoading}
+            >
+              <Text style={styles.linkText}>アカウントを作成 → サインアップ</Text>
+            </TouchableOpacity>
+          )}
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -178,5 +199,13 @@ const styles = StyleSheet.create({
     color: COLORS.text.dark,
     fontSize: 23,
     fontWeight: '600',
+  },
+  linkButton: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  linkText: {
+    color: '#94A3B8',
+    fontSize: 18,
   },
 });

--- a/src/features/auth/SignupScreen.tsx
+++ b/src/features/auth/SignupScreen.tsx
@@ -1,0 +1,278 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  SafeAreaView,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+} from 'react-native';
+import { COLORS } from '@shared/constants';
+import { supabase, isSupabaseConfigured } from '@shared/lib';
+import { useAuthStore } from './authStore';
+
+export interface SignupScreenProps {
+  /** サインアップ成功時（セッション取得済み） */
+  onSignupSuccess?: () => void;
+  /** 「すでにアカウントがある」でログインへ */
+  onNavigateToLogin?: () => void;
+}
+
+/**
+ * サインアップ画面
+ * Supabase Auth でメール/パスワードで新規登録する。
+ * メール確認が有効な場合は「確認メールを送りました」と表示し、ログインへ誘導する。
+ */
+export const SignupScreen: React.FC<SignupScreenProps> = ({
+  onSignupSuccess,
+  onNavigateToLogin,
+}) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const setUser = useAuthStore(s => s.setUser);
+
+  const handleSignup = async () => {
+    setError(null);
+    setMessage(null);
+    if (password !== confirmPassword) {
+      setError('パスワードが一致しません');
+      return;
+    }
+    if (password.length < 6) {
+      setError('パスワードは6文字以上にしてください');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      if (!isSupabaseConfigured() || !supabase) {
+        setError('認証が未設定です。task dev-up で環境を用意してください。');
+        return;
+      }
+      const { data, error: signUpError } = await supabase.auth.signUp({
+        email: email.trim(),
+        password,
+      });
+      if (signUpError) {
+        setError(signUpError.message ?? '登録に失敗しました');
+        return;
+      }
+      const user = data?.user;
+      if (!user) {
+        setError('登録に失敗しました');
+        return;
+      }
+      // メール確認が必要な場合、session は null のことがある
+      const session = data?.session;
+      if (session?.user) {
+        setUser({
+          id: session.user.id,
+          email: session.user.email ?? '',
+          name: session.user.user_metadata?.name ?? session.user.email ?? undefined,
+        });
+        onSignupSuccess?.();
+        return;
+      }
+      setMessage(
+        '確認メールを送信しました。メール内のリンクから認証を完了してください。'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.keyboardView}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.header}>
+            <Text style={styles.title}>アカウント作成</Text>
+            <Text style={styles.subtitle}>
+              メールアドレスとパスワードで新規登録
+            </Text>
+          </View>
+
+          <View style={styles.form}>
+            {error && (
+              <View style={styles.errorContainer}>
+                <Text style={styles.errorText}>{error}</Text>
+              </View>
+            )}
+            {message && (
+              <View style={styles.messageContainer}>
+                <Text style={styles.messageText}>{message}</Text>
+              </View>
+            )}
+
+            <View style={styles.inputContainer}>
+              <Text style={styles.label}>メールアドレス</Text>
+              <TextInput
+                style={styles.input}
+                value={email}
+                onChangeText={setEmail}
+                placeholder="example@email.com"
+                placeholderTextColor="#64748B"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                editable={!isLoading}
+              />
+            </View>
+
+            <View style={styles.inputContainer}>
+              <Text style={styles.label}>パスワード（6文字以上）</Text>
+              <TextInput
+                style={styles.input}
+                value={password}
+                onChangeText={setPassword}
+                placeholder="パスワードを入力"
+                placeholderTextColor="#64748B"
+                secureTextEntry
+                editable={!isLoading}
+              />
+            </View>
+
+            <View style={styles.inputContainer}>
+              <Text style={styles.label}>パスワード（確認）</Text>
+              <TextInput
+                style={styles.input}
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+                placeholder="もう一度入力"
+                placeholderTextColor="#64748B"
+                secureTextEntry
+                editable={!isLoading}
+              />
+            </View>
+
+            <TouchableOpacity
+              style={[styles.button, isLoading && styles.buttonDisabled]}
+              onPress={handleSignup}
+              disabled={isLoading}
+            >
+              <Text style={styles.buttonText}>
+                {isLoading ? '登録中...' : '登録する'}
+              </Text>
+            </TouchableOpacity>
+
+            {onNavigateToLogin && (
+              <TouchableOpacity
+                style={styles.linkButton}
+                onPress={onNavigateToLogin}
+                disabled={isLoading}
+              >
+                <Text style={styles.linkText}>
+                  すでにアカウントがある → ログイン
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1E293B',
+  },
+  keyboardView: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+  },
+  header: {
+    marginBottom: 32,
+  },
+  title: {
+    fontSize: 42,
+    fontWeight: 'bold',
+    color: COLORS.text.dark,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 21,
+    color: COLORS.text.dark,
+    opacity: 0.7,
+  },
+  form: {
+    gap: 20,
+  },
+  errorContainer: {
+    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+    borderRadius: 8,
+    padding: 12,
+  },
+  errorText: {
+    color: COLORS.error,
+    fontSize: 18,
+    textAlign: 'center',
+  },
+  messageContainer: {
+    backgroundColor: 'rgba(34, 197, 94, 0.1)',
+    borderRadius: 8,
+    padding: 12,
+  },
+  messageText: {
+    color: '#22c55e',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  inputContainer: {
+    gap: 8,
+  },
+  label: {
+    fontSize: 18,
+    color: COLORS.text.dark,
+    fontWeight: '500',
+  },
+  input: {
+    backgroundColor: COLORS.background.dark,
+    borderRadius: 12,
+    padding: 16,
+    fontSize: 21,
+    color: COLORS.text.dark,
+    borderWidth: 1,
+    borderColor: '#334155',
+  },
+  button: {
+    backgroundColor: COLORS.primary,
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: COLORS.text.dark,
+    fontSize: 23,
+    fontWeight: '600',
+  },
+  linkButton: {
+    padding: 16,
+    alignItems: 'center',
+  },
+  linkText: {
+    color: '#94A3B8',
+    fontSize: 18,
+  },
+});

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -2,4 +2,7 @@
  * Auth Feature - Public API
  */
 export { LoginScreen } from './LoginScreen';
+export type { LoginScreenProps } from './LoginScreen';
+export { SignupScreen } from './SignupScreen';
+export type { SignupScreenProps } from './SignupScreen';
 export { useAuthStore } from './authStore';

--- a/src/features/sleep-settings/SleepSettingsScreen.tsx
+++ b/src/features/sleep-settings/SleepSettingsScreen.tsx
@@ -9,7 +9,9 @@ import {
   TextInput,
   ScrollView,
 } from 'react-native';
+import { useRouter } from 'expo-router';
 import { COLORS } from '@shared/constants';
+import { useAuthStore } from '@features/auth';
 import { useSleepSettingsStore } from './sleepSettingsStore';
 
 /**
@@ -17,7 +19,14 @@ import { useSleepSettingsStore } from './sleepSettingsStore';
  * 起床時刻と睡眠時間を設定し、就寝予定時刻を自動計算する
  */
 export const SleepSettingsScreen: React.FC = () => {
+  const router = useRouter();
   const settings = useSleepSettingsStore();
+  const logout = useAuthStore(s => s.logout);
+
+  const handleLogout = async () => {
+    await logout();
+    router.replace('/(auth)/login');
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -125,6 +134,13 @@ export const SleepSettingsScreen: React.FC = () => {
               <Text style={styles.durationButtonText}>＋</Text>
             </TouchableOpacity>
           </View>
+        </View>
+
+        {/* ログアウト */}
+        <View style={styles.logoutCard}>
+          <TouchableOpacity style={styles.logoutButton} onPress={handleLogout}>
+            <Text style={styles.logoutButtonText}>ログアウト</Text>
+          </TouchableOpacity>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -241,5 +257,21 @@ const styles = StyleSheet.create({
     padding: 10,
     borderRadius: 8,
     width: '100%',
+  },
+  logoutCard: {
+    marginTop: 24,
+    marginBottom: 32,
+  },
+  logoutButton: {
+    backgroundColor: 'transparent',
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#64748B',
+  },
+  logoutButtonText: {
+    color: '#94A3B8',
+    fontSize: 18,
   },
 });

--- a/src/shared/lib/supabase.ts
+++ b/src/shared/lib/supabase.ts
@@ -17,6 +17,9 @@ const extra = (Constants.expoConfig?.extra ?? {}) as {
 const supabaseUrl = (extra.supabaseUrl ?? '').trim();
 const supabaseAnonKey = (extra.supabaseAnonKey ?? '').trim();
 
+if (__DEV__ && (supabaseUrl || supabaseAnonKey)) {
+  console.log('[supabase] using url:', supabaseUrl || '(missing)');
+}
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn(
     '[supabase] EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY is missing. Auth will not work until .env.expo.local is set (e.g. task dev-up).'


### PR DESCRIPTION
## 概要
- 各 API 呼び出しに認証トークン付与（3.1）
- ログイン・サインアップ画面とルーティング
- 実機/エミュレータで Supabase・API に届くよう URL 差し替えと Metro 停止タスク

## 主な変更
- **認証**: 共通 apiClient（Authorization 付与）、Supabase Auth 連携、sleepPlanApi で apiV1Fetch 使用
- **UI**: ログイン/サインアップ画面、認証グループ (auth) ルート、設定画面にログアウト
- **エミュレータ**: write-expo-env で Supabase URL を 10.0.2.2 に、実機は LAN IP に
- **Taskfile**: `task metro-stop` 追加（ポート 8081 停止）
- **ドキュメント**: docs/troubleshooting-emulator-network.md

## 参照
- docs/implementation-plan.md 3.1
- docs/backend-design.md §2, §9

Made with [Cursor](https://cursor.com)