### PR TITLE
feat(sleep-log): フロント睡眠ログ API 連携 Closes #25

### DIFF
--- a/src/features/home/HomeScreen.tsx
+++ b/src/features/home/HomeScreen.tsx
@@ -25,16 +25,17 @@ import { MorningReviewCard } from './components/MorningReviewCard';
 export const HomeScreen: React.FC = () => {
   const router = useRouter();
   const settings = useSleepSettingsStore();
-  const { logs, setMood } = useSleepLogStore();
+  const { logs, setMood, fetchLogs } = useSleepLogStore();
   const latestLog = logs[0] ?? null;
   const latestScore = latestLog?.score ?? null;
   const { plan, fetchPlan } = useSleepPlanStore();
   const todayPlan = useSleepPlanStore(state => state.getTodayPlan());
 
-  // プランを取得（キャッシュ期限内ならスキップ）
+  // ログとプランを取得
   useEffect(() => {
+    void fetchLogs();
     void fetchPlan();
-  }, [fetchPlan]);
+  }, [fetchLogs, fetchPlan]);
 
   // オーバーライド考慮の有効な時刻
   const effectiveSleep = settings.getEffectiveSleepTime();
@@ -151,7 +152,7 @@ export const HomeScreen: React.FC = () => {
             <MorningReviewCard
               score={latestScore}
               initialMood={latestLog.mood}
-              onSelectMood={mood => setMood(latestLog.id, mood)}
+              onSelectMood={mood => void setMood(latestLog.id, mood)}
             />
           )}
 

--- a/src/features/sleep-log/SleepLogScreen.tsx
+++ b/src/features/sleep-log/SleepLogScreen.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, StyleSheet, SafeAreaView, ScrollView } from 'react-native';
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet, SafeAreaView, ScrollView, ActivityIndicator } from 'react-native';
 import { COLORS } from '@shared/constants';
 import { useSleepLogStore } from './sleepLogStore';
 import { SleepScoreDisplay } from './components/SleepScoreDisplay';
@@ -11,7 +11,11 @@ import { WeeklyTrendChart } from './components/WeeklyTrendChart';
  * 過去の睡眠準備スコアの履歴を表示
  */
 export const SleepLogScreen: React.FC = () => {
-  const { logs } = useSleepLogStore();
+  const { logs, isLoading, fetchLogs } = useSleepLogStore();
+
+  useEffect(() => {
+    void fetchLogs();
+  }, [fetchLogs]);
   const latestLog = logs[0] ?? null;
 
   return (
@@ -23,6 +27,13 @@ export const SleepLogScreen: React.FC = () => {
       </View>
 
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        {/* ローディング */}
+        {isLoading && logs.length === 0 && (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color={COLORS.primary} />
+          </View>
+        )}
+
         {/* 最新スコア */}
         {latestLog && (
           <View style={styles.latestCard}>
@@ -96,5 +107,9 @@ const styles = StyleSheet.create({
     fontSize: 17,
     color: '#64748B',
     fontWeight: '500',
+  },
+  loadingContainer: {
+    paddingVertical: 40,
+    alignItems: 'center',
   },
 });

--- a/src/features/sleep-log/index.ts
+++ b/src/features/sleep-log/index.ts
@@ -4,3 +4,8 @@
 export { SleepLogScreen } from './SleepLogScreen';
 export { useSleepLogStore } from './sleepLogStore';
 export type { SleepLogEntry } from './types';
+export {
+  fetchSleepLogsFromApi,
+  createSleepLogViaApi,
+  updateSleepLogMoodViaApi,
+} from './sleepLogApi';

--- a/src/features/sleep-log/sleepLogApi.ts
+++ b/src/features/sleep-log/sleepLogApi.ts
@@ -1,0 +1,153 @@
+/**
+ * 睡眠ログ API クライアント
+ *
+ * GET    /api/v1/sleep-logs        — ログ一覧取得
+ * POST   /api/v1/sleep-logs        — ログ新規作成
+ * PATCH  /api/v1/sleep-logs/:id    — 気分（mood）更新
+ *
+ * バックエンドは snake_case、フロントは camelCase なので変換を行う。
+ */
+
+import { apiV1Fetch } from '@shared/lib';
+import type { SleepLogEntry } from './types';
+
+/* ------------------------------------------------------------------ */
+/*  Backend ↔ Frontend 型変換                                          */
+/* ------------------------------------------------------------------ */
+
+/** バックエンドのレスポンス型（snake_case） */
+interface SleepLogApiResponse {
+  id: string;
+  user_id: string;
+  date: string; // "YYYY-MM-DD"
+  score: number;
+  scheduled_sleep_time: string | null; // ISO datetime
+  usage_penalty: number;
+  environment_penalty: number;
+  phase1_warning: boolean;
+  phase2_warning: boolean;
+  light_exceeded: boolean;
+  noise_exceeded: boolean;
+  mood: number | null;
+  created_at: string; // ISO datetime
+}
+
+/** バックエンドのリスト取得レスポンス */
+interface SleepLogListApiResponse {
+  logs: SleepLogApiResponse[];
+  total: number;
+}
+
+/** POST リクエスト Body（snake_case） */
+interface SleepLogCreateRequest {
+  date: string;
+  score: number;
+  scheduled_sleep_time: string | null;
+  usage_penalty: number;
+  environment_penalty: number;
+  phase1_warning: boolean;
+  phase2_warning: boolean;
+  light_exceeded: boolean;
+  noise_exceeded: boolean;
+  mood: number | null;
+}
+
+/** PATCH リクエスト Body（snake_case） */
+interface SleepLogMoodUpdateRequest {
+  mood: number;
+}
+
+/** snake_case レスポンス → camelCase フロント型 */
+function responseToCamel(res: SleepLogApiResponse): SleepLogEntry {
+  return {
+    id: res.id,
+    date: res.date,
+    score: res.score,
+    scheduledSleepTime: res.scheduled_sleep_time
+      ? new Date(res.scheduled_sleep_time).getTime()
+      : 0,
+    usagePenalty: res.usage_penalty,
+    environmentPenalty: res.environment_penalty,
+    phase1Warning: res.phase1_warning,
+    phase2Warning: res.phase2_warning,
+    lightExceeded: res.light_exceeded,
+    noiseExceeded: res.noise_exceeded,
+    mood: res.mood,
+    createdAt: new Date(res.created_at).getTime(),
+  };
+}
+
+/** camelCase フロント型 → snake_case POST リクエスト */
+function entryToSnake(
+  entry: Omit<SleepLogEntry, 'id' | 'createdAt' | 'mood'>
+): SleepLogCreateRequest {
+  return {
+    date: entry.date,
+    score: entry.score,
+    scheduled_sleep_time: entry.scheduledSleepTime
+      ? new Date(entry.scheduledSleepTime).toISOString()
+      : null,
+    usage_penalty: entry.usagePenalty,
+    environment_penalty: entry.environmentPenalty,
+    phase1_warning: entry.phase1Warning,
+    phase2_warning: entry.phase2Warning,
+    light_exceeded: entry.lightExceeded,
+    noise_exceeded: entry.noiseExceeded,
+    mood: null,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * GET /api/v1/sleep-logs — 睡眠ログ一覧を取得する（日付降順）。
+ */
+export async function fetchSleepLogsFromApi(
+  limit = 7
+): Promise<SleepLogEntry[]> {
+  const res = await apiV1Fetch(`/sleep-logs?limit=${limit}`);
+  if (!res.ok) {
+    throw new Error(`GET /sleep-logs failed: ${res.status}`);
+  }
+  const data: SleepLogListApiResponse = await res.json();
+  return data.logs.map(responseToCamel);
+}
+
+/**
+ * POST /api/v1/sleep-logs — 睡眠ログを新規作成する。
+ */
+export async function createSleepLogViaApi(
+  entry: Omit<SleepLogEntry, 'id' | 'createdAt' | 'mood'>
+): Promise<SleepLogEntry> {
+  const body = entryToSnake(entry);
+  const res = await apiV1Fetch('/sleep-logs', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /sleep-logs failed: ${res.status}`);
+  }
+  const data: SleepLogApiResponse = await res.json();
+  return responseToCamel(data);
+}
+
+/**
+ * PATCH /api/v1/sleep-logs/:id — 睡眠ログの気分を更新する（朝の振り返り用）。
+ */
+export async function updateSleepLogMoodViaApi(
+  logId: string,
+  mood: number
+): Promise<SleepLogEntry> {
+  const body: SleepLogMoodUpdateRequest = { mood };
+  const res = await apiV1Fetch(`/sleep-logs/${logId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`PATCH /sleep-logs/${logId} failed: ${res.status}`);
+  }
+  const data: SleepLogApiResponse = await res.json();
+  return responseToCamel(data);
+}

--- a/src/features/sleep-log/sleepLogStore.ts
+++ b/src/features/sleep-log/sleepLogStore.ts
@@ -1,51 +1,80 @@
 import { create } from 'zustand';
 import type { SleepLogEntry } from './types';
-import { mockSleepLogs } from './mockData';
+import {
+  fetchSleepLogsFromApi,
+  createSleepLogViaApi,
+  updateSleepLogMoodViaApi,
+} from './sleepLogApi';
 
 interface SleepLogState {
   /** ログ一覧（新しい順） */
   logs: SleepLogEntry[];
+  /** API 通信中フラグ */
+  isLoading: boolean;
+  /** 最終取得日時 */
+  lastFetchedAt: number | null;
 }
 
 interface SleepLogActions {
-  /** ログを追加 */
-  addLog: (entry: Omit<SleepLogEntry, 'id' | 'createdAt' | 'mood'>) => void;
-  /** ログの気分を設定 */
-  setMood: (logId: string, mood: number) => void;
-  /** ログを削除 */
+  /** バックエンドからログ一覧を取得して store を更新 */
+  fetchLogs: (limit?: number) => Promise<void>;
+  /** ログを追加（API POST → store 更新） */
+  addLog: (entry: Omit<SleepLogEntry, 'id' | 'createdAt' | 'mood'>) => Promise<void>;
+  /** ログの気分を設定（API PATCH → store 更新） */
+  setMood: (logId: string, mood: number) => Promise<void>;
+  /** ログを削除（ローカルのみ） */
   removeLog: (id: string) => void;
-  /** 全ログをクリア */
+  /** 全ログをクリア（ローカルのみ） */
   clearLogs: () => void;
 }
 
 /**
  * 睡眠ログストア
- * スコア履歴の保存と取得を管理
- * TODO: AsyncStorageで永続化
+ * バックエンド API と連携してスコア履歴の保存と取得を管理
  */
-export const useSleepLogStore = create<SleepLogState & SleepLogActions>(set => ({
-  logs: mockSleepLogs,
+export const useSleepLogStore = create<SleepLogState & SleepLogActions>((set, get) => ({
+  logs: [],
+  isLoading: false,
+  lastFetchedAt: null,
 
-  addLog: entry => {
-    const newLog: SleepLogEntry = {
-      ...entry,
-      id: `log-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-      mood: null,
-      createdAt: Date.now(),
-    };
-    set(state => ({
-      logs: [newLog, ...state.logs],
-    }));
+  fetchLogs: async (limit = 7) => {
+    set({ isLoading: true });
+    try {
+      const logs = await fetchSleepLogsFromApi(limit);
+      set({ logs, isLoading: false, lastFetchedAt: Date.now() });
+    } catch (err) {
+      console.warn('[sleepLogStore] fetchLogs failed:', err);
+      set({ isLoading: false });
+    }
+  },
+
+  addLog: async entry => {
+    try {
+      const created = await createSleepLogViaApi(entry);
+      set(state => ({
+        logs: [created, ...state.logs],
+      }));
+    } catch (err) {
+      console.warn('[sleepLogStore] addLog failed:', err);
+      throw err;
+    }
+  },
+
+  setMood: async (logId, mood) => {
+    try {
+      const updated = await updateSleepLogMoodViaApi(logId, mood);
+      set(state => ({
+        logs: state.logs.map(log => (log.id === updated.id ? updated : log)),
+      }));
+    } catch (err) {
+      console.warn('[sleepLogStore] setMood failed:', err);
+      throw err;
+    }
   },
 
   removeLog: id =>
     set(state => ({
       logs: state.logs.filter(log => log.id !== id),
-    })),
-
-  setMood: (logId, mood) =>
-    set(state => ({
-      logs: state.logs.map(log => (log.id === logId ? { ...log, mood } : log)),
     })),
 
   clearLogs: () => set({ logs: [] }),


### PR DESCRIPTION
- sleepLogApi.ts: GET/POST/PATCH /api/v1/sleep-logs のAPIクライアント作成（snake_case/camelCase変換含む）
- sleepLogStore.ts: モックデータを廃止し、API経由でログ取得・作成・気分更新を行うように変更
- SleepLogScreen.tsx: マウント時にfetchLogsを呼び出し、ローディング表示を追加
- HomeScreen.tsx: マウント時にfetchLogsを呼び出し、setMoodをasync対応