### PR TITLE
ci: フロントビルド・DB待機・バックエンドLint/型チェックを強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Format check
         run: pnpm run format:check
 
+      - name: Build (expo export web)
+        run: npx expo export --platform web
+
   backend:
     name: Backend (dev-up + pytest)
     runs-on: ubuntu-latest
@@ -95,18 +98,33 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          cache: "pip"
 
-      - name: Wait for DB and run migrations
+      - name: Wait for DB
+        run: node scripts/wait-for-db.mjs
+
+      - name: Install backend deps and run migrations
         run: |
-          echo "Waiting for DB..."
-          sleep 5
           cd backend && uv sync && \
           DATABASE_URL=postgresql://postgres:postgres@localhost:5432/sleepsupport uv run alembic upgrade head
 
-      - name: Install backend dependencies and run pytest
+      - name: Install backend dev deps
+        run: cd backend && uv sync --extra dev
+
+      - name: Lint (ruff)
         run: |
           cd backend
-          uv sync --extra dev
+          uv run ruff check .
+          uv run ruff format --check .
+
+      - name: Type check (mypy)
+        continue-on-error: true
+        run: cd backend && uv run mypy app
+        # 型エラー解消後に continue-on-error を外す
+
+      - name: Pytest
+        run: |
+          cd backend
           DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/sleepsupport uv run pytest tests/ -v
 
   expo-android:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,4 +31,4 @@ ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 
 ENTRYPOINT []
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:web_app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/IMPLEMENT_README.md
+++ b/backend/IMPLEMENT_README.md
@@ -109,7 +109,7 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/sleepsupport uv run a
 uv run alembic revision --autogenerate -m "add_sleep_settings_and_sleep_logs"
 
 # API をローカルで起動（DB が別途起動していること）
-uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+uv run uvicorn app.main:web_app --reload --host 0.0.0.0 --port 8000
 ```
 
 **Docker で API と DB をまとめて起動する場合**（リポジトリルートで）:

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -6,11 +6,11 @@ app の Base とモデルを読み込み、DATABASE_URL を同期用に変換し
 from logging.config import fileConfig
 
 from sqlalchemy import create_engine, pool
-from alembic import context
 
+import app.infrastructure.persistence.models  # noqa: F401 - metadata 登録
+from alembic import context
 from app.config import settings
 from app.infrastructure.persistence.database import Base
-import app.infrastructure.persistence.models  # noqa: F401 - metadata 登録
 
 config = context.config
 if config.config_file_name is not None:

--- a/backend/app/application/plan/get_or_create_plan.py
+++ b/backend/app/application/plan/get_or_create_plan.py
@@ -11,10 +11,10 @@ import json
 import logging
 from typing import Any
 
+from app.application.base import BaseUseCase
+from app.application.plan.ports import IPlanGenerator
 from app.domain.plan.repositories import IPlanCacheRepository
 from app.domain.plan.value_objects import build_signature_hash
-from app.application.plan.ports import IPlanGenerator
-from app.application.base import BaseUseCase
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +71,7 @@ class GetOrCreatePlanUseCase(BaseUseCase[GetOrCreatePlanInput, dict[str, Any]]):
 
         # force=True でなければキャッシュを検索
         if not input.force:
-            cached = await self.cache_repo.get_by_user_and_hash(
-                input.user_id, signature_hash
-            )
+            cached = await self.cache_repo.get_by_user_and_hash(input.user_id, signature_hash)
             if cached:
                 logger.info("plan cache_hit signature_hash=%s", signature_hash)
                 plan = json.loads(cached.plan_json)

--- a/backend/app/application/settings/put_settings.py
+++ b/backend/app/application/settings/put_settings.py
@@ -2,11 +2,17 @@
 PutSettingsUseCase - 睡眠設定の保存（upsert）
 """
 
+from __future__ import annotations
+
 from datetime import date
+from typing import TYPE_CHECKING
 
 from app.infrastructure.persistence.repositories.sleep_settings_repository import (
     SleepSettingsRepository,
 )
+
+if TYPE_CHECKING:
+    from app.infrastructure.persistence.models.sleep_settings import SleepSettings
 
 
 class PutSettingsUseCase:
@@ -15,9 +21,8 @@ class PutSettingsUseCase:
     def __init__(self, settings_repo: SleepSettingsRepository):
         self.settings_repo = settings_repo
 
-    async def execute(self, user_id: str, payload: "PutSettingsPayload") -> "SleepSettings":
+    async def execute(self, user_id: str, payload: PutSettingsPayload) -> SleepSettings:
         """設定を upsert して保存済みエンティティを返す。"""
-        from app.infrastructure.persistence.models.sleep_settings import SleepSettings
 
         override_date = None
         override_sleep_hour = None
@@ -67,7 +72,7 @@ class PutSettingsPayload:
         mission_target: str | None = None,
         preparation_minutes: int = 30,
         ics_url: str | None = None,
-        today_override: "TodayOverrideInput | None" = None,
+        today_override: TodayOverrideInput | None = None,
     ):
         self.wake_up_hour = wake_up_hour
         self.wake_up_minute = wake_up_minute

--- a/backend/app/application/sleep_log/__init__.py
+++ b/backend/app/application/sleep_log/__init__.py
@@ -1,5 +1,5 @@
-from app.application.sleep_log.get_sleep_logs import GetSleepLogsUseCase
 from app.application.sleep_log.create_sleep_log import CreateSleepLogUseCase
+from app.application.sleep_log.get_sleep_logs import GetSleepLogsUseCase
 from app.application.sleep_log.update_mood import UpdateMoodUseCase
 
 __all__ = [

--- a/backend/app/application/user/__init__.py
+++ b/backend/app/application/user/__init__.py
@@ -1,9 +1,9 @@
 """User ユースケース"""
 
 from app.application.user.create_user import CreateUserUseCase
-from app.application.user.get_user import GetUserUseCase, GetAllUsersUseCase
-from app.application.user.update_user import UpdateUserUseCase
 from app.application.user.delete_user import DeleteUserUseCase
+from app.application.user.get_user import GetAllUsersUseCase, GetUserUseCase
+from app.application.user.update_user import UpdateUserUseCase
 
 __all__ = [
     "CreateUserUseCase",

--- a/backend/app/application/user/create_user.py
+++ b/backend/app/application/user/create_user.py
@@ -4,8 +4,8 @@ CreateUserUseCase - ユーザー作成のビジネスロジック
 
 from fastapi import HTTPException, status
 
-from app.domain.user.repositories import IUserRepository
 from app.application.base import BaseUseCase
+from app.domain.user.repositories import IUserRepository
 
 
 class CreateUserUseCase(BaseUseCase[dict, object]):

--- a/backend/app/application/user/delete_user.py
+++ b/backend/app/application/user/delete_user.py
@@ -4,8 +4,8 @@ DeleteUserUseCase - ユーザー削除のビジネスロジック
 
 from fastapi import HTTPException, status
 
-from app.domain.user.repositories import IUserRepository
 from app.application.base import BaseUseCase
+from app.domain.user.repositories import IUserRepository
 
 
 class DeleteUserUseCase(BaseUseCase[str, None]):

--- a/backend/app/application/user/get_user.py
+++ b/backend/app/application/user/get_user.py
@@ -2,12 +2,12 @@
 GetUserUseCase / GetAllUsersUseCase - ユーザー取得のビジネスロジック
 """
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from fastapi import HTTPException, status
 
-from app.domain.user.repositories import IUserRepository
 from app.application.base import BaseUseCase, NoInputUseCase
+from app.domain.user.repositories import IUserRepository
 
 
 class GetUserUseCase(BaseUseCase[str, object]):

--- a/backend/app/application/user/update_user.py
+++ b/backend/app/application/user/update_user.py
@@ -4,8 +4,8 @@ UpdateUserUseCase - ユーザー更新のビジネスロジック
 
 from fastapi import HTTPException, status
 
-from app.domain.user.repositories import IUserRepository
 from app.application.base import BaseUseCase
+from app.domain.user.repositories import IUserRepository
 
 
 class UpdateUserUseCase(BaseUseCase[tuple[str, dict], object]):
@@ -30,6 +30,6 @@ class UpdateUserUseCase(BaseUseCase[tuple[str, dict], object]):
             )
 
         if data.get("name") is not None:
-            setattr(user, "name", data["name"])
+            user.name = data["name"]
 
         return await self.user_repo.update(user)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
     )
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> Settings:
     """設定のシングルトンインスタンスを取得"""
     return Settings()

--- a/backend/app/domain/plan/repositories.py
+++ b/backend/app/domain/plan/repositories.py
@@ -25,8 +25,6 @@ class IPlanCacheRepository(Protocol):
         """user_id で1件取得（1ユーザー1行のため）"""
         ...
 
-    async def upsert(
-        self, user_id: str, signature_hash: str, plan_json: str
-    ) -> PlanCacheRecord:
+    async def upsert(self, user_id: str, signature_hash: str, plan_json: str) -> PlanCacheRecord:
         """同一 user_id の行を上書き（なければ INSERT）"""
         ...

--- a/backend/app/domain/sleep_log/repositories.py
+++ b/backend/app/domain/sleep_log/repositories.py
@@ -3,8 +3,9 @@
 Infrastructure 層がこのインターフェースを実装する。
 """
 
+from collections.abc import Sequence
 from datetime import date, datetime
-from typing import Protocol, Sequence
+from typing import Protocol
 
 
 class SleepLogRecord(Protocol):
@@ -28,9 +29,7 @@ class SleepLogRecord(Protocol):
 class ISleepLogRepository(Protocol):
     """睡眠ログのリポジトリポート"""
 
-    async def get_by_user(
-        self, user_id: str, limit: int = 7
-    ) -> Sequence[SleepLogRecord]:
+    async def get_by_user(self, user_id: str, limit: int = 7) -> Sequence[SleepLogRecord]:
         """user_id のログを日付降順で取得"""
         ...
 
@@ -55,8 +54,6 @@ class ISleepLogRepository(Protocol):
         """睡眠ログを新規作成"""
         ...
 
-    async def update_mood(
-        self, log_id: str, user_id: str, mood: int
-    ) -> SleepLogRecord | None:
+    async def update_mood(self, log_id: str, user_id: str, mood: int) -> SleepLogRecord | None:
         """指定ログの気分を更新"""
         ...

--- a/backend/app/domain/user/repositories.py
+++ b/backend/app/domain/user/repositories.py
@@ -3,7 +3,8 @@
 Infrastructure 層がこのインターフェースを実装する。
 """
 
-from typing import Protocol, Sequence
+from collections.abc import Sequence
+from typing import Protocol
 
 
 class IUserRepository(Protocol):

--- a/backend/app/infrastructure/llm/openrouter_client.py
+++ b/backend/app/infrastructure/llm/openrouter_client.py
@@ -115,14 +115,9 @@ class OpenRouterClient:
             "    ... 7日分\n"
             "  ]\n"
             "}\n\n"
-            "カレンダー予定: "
-            + json.dumps(calendar_events, ensure_ascii=False)
-            + "\n\n"
-            "睡眠ログ: "
-            + json.dumps(sleep_logs, ensure_ascii=False)
-            + "\n\n"
-            "設定: "
-            + json.dumps(settings, ensure_ascii=False)
+            "カレンダー予定: " + json.dumps(calendar_events, ensure_ascii=False) + "\n\n"
+            "睡眠ログ: " + json.dumps(sleep_logs, ensure_ascii=False) + "\n\n"
+            "設定: " + json.dumps(settings, ensure_ascii=False)
         )
         if today_override is not None:
             user_content += (
@@ -154,8 +149,4 @@ class OpenRouterClient:
         )
         if isinstance(result, dict) and "week_plan" in result:
             return result
-        return (
-            {"week_plan": result}
-            if isinstance(result, list)
-            else {"week_plan": [result]}
-        )
+        return {"week_plan": result} if isinstance(result, list) else {"week_plan": [result]}

--- a/backend/app/infrastructure/persistence/database.py
+++ b/backend/app/infrastructure/persistence/database.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import DeclarativeBase
 
 from app.config import settings
 
-
 engine = create_async_engine(
     settings.DATABASE_URL,
     echo=settings.DEBUG,
@@ -29,6 +28,7 @@ AsyncSessionLocal = async_sessionmaker(
 
 class Base(DeclarativeBase):
     """SQLAlchemy モデルの基底クラス"""
+
     pass
 
 

--- a/backend/app/infrastructure/persistence/models/__init__.py
+++ b/backend/app/infrastructure/persistence/models/__init__.py
@@ -3,9 +3,9 @@ SQLAlchemy ORM モデル
 """
 
 from app.infrastructure.persistence.database import Base
-from app.infrastructure.persistence.models.user import User
+from app.infrastructure.persistence.models.sleep_log import SleepLog
 from app.infrastructure.persistence.models.sleep_plan_cache import SleepPlanCache
 from app.infrastructure.persistence.models.sleep_settings import SleepSettings
-from app.infrastructure.persistence.models.sleep_log import SleepLog
+from app.infrastructure.persistence.models.user import User
 
 __all__ = ["Base", "User", "SleepPlanCache", "SleepSettings", "SleepLog"]

--- a/backend/app/infrastructure/persistence/models/sleep_log.py
+++ b/backend/app/infrastructure/persistence/models/sleep_log.py
@@ -35,21 +35,11 @@ class SleepLog(Base):
         DateTime(timezone=True), nullable=True
     )
     usage_penalty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    environment_penalty: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0
-    )
-    phase1_warning: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    phase2_warning: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    light_exceeded: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    noise_exceeded: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
+    environment_penalty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    phase1_warning: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    phase2_warning: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    light_exceeded: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    noise_exceeded: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     mood: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/app/infrastructure/persistence/models/sleep_plan_cache.py
+++ b/backend/app/infrastructure/persistence/models/sleep_plan_cache.py
@@ -22,9 +22,7 @@ class SleepPlanCache(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    signature_hash: Mapped[str] = mapped_column(
-        String(64), nullable=False, index=True
-    )
+    signature_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     plan_json: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/app/infrastructure/persistence/models/sleep_settings.py
+++ b/backend/app/infrastructure/persistence/models/sleep_settings.py
@@ -24,41 +24,19 @@ class SleepSettings(Base):
     )
     wake_up_hour: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
     wake_up_minute: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    sleep_duration_hours: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=8
-    )
-    resilience_window_minutes: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=20
-    )
-    mission_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False
-    )
-    mission_target: Mapped[str | None] = mapped_column(
-        String(255), nullable=True, default=None
-    )
-    preparation_minutes: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=30
-    )
-    ics_url: Mapped[str | None] = mapped_column(
-        String(2048), nullable=True, default=None
-    )
+    sleep_duration_hours: Mapped[int] = mapped_column(Integer, nullable=False, default=8)
+    resilience_window_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
+    mission_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    mission_target: Mapped[str | None] = mapped_column(String(255), nullable=True, default=None)
+    preparation_minutes: Mapped[int] = mapped_column(Integer, nullable=False, default=30)
+    ics_url: Mapped[str | None] = mapped_column(String(2048), nullable=True, default=None)
 
     # 今日のオーバーライド（nullable）
-    override_date: Mapped[date | None] = mapped_column(
-        Date, nullable=True, default=None
-    )
-    override_sleep_hour: Mapped[int | None] = mapped_column(
-        Integer, nullable=True, default=None
-    )
-    override_sleep_minute: Mapped[int | None] = mapped_column(
-        Integer, nullable=True, default=None
-    )
-    override_wake_hour: Mapped[int | None] = mapped_column(
-        Integer, nullable=True, default=None
-    )
-    override_wake_minute: Mapped[int | None] = mapped_column(
-        Integer, nullable=True, default=None
-    )
+    override_date: Mapped[date | None] = mapped_column(Date, nullable=True, default=None)
+    override_sleep_hour: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    override_sleep_minute: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    override_wake_hour: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    override_wake_minute: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/app/infrastructure/persistence/repositories/base.py
+++ b/backend/app/infrastructure/persistence/repositories/base.py
@@ -2,7 +2,8 @@
 Repository 基底クラス（Infrastructure 層）
 """
 
-from typing import Generic, Optional, Sequence, Type, TypeVar
+from collections.abc import Sequence
+from typing import Generic, TypeVar
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,24 +16,18 @@ ModelT = TypeVar("ModelT", bound=Base)
 class BaseRepository(Generic[ModelT]):
     """Repository 基底クラス"""
 
-    def __init__(self, model: Type[ModelT], db: AsyncSession):
+    def __init__(self, model: type[ModelT], db: AsyncSession):
         self.model = model
         self.db = db
 
-    async def get_by_id(self, id: str) -> Optional[ModelT]:
+    async def get_by_id(self, id: str) -> ModelT | None:
         """ID で 1 件取得"""
-        result = await self.db.execute(
-            select(self.model).where(self.model.id == id)
-        )
+        result = await self.db.execute(select(self.model).where(self.model.id == id))
         return result.scalar_one_or_none()
 
-    async def get_all(
-        self, skip: int = 0, limit: int = 100
-    ) -> Sequence[ModelT]:
+    async def get_all(self, skip: int = 0, limit: int = 100) -> Sequence[ModelT]:
         """全件取得（ページネーション付き）"""
-        result = await self.db.execute(
-            select(self.model).offset(skip).limit(limit)
-        )
+        result = await self.db.execute(select(self.model).offset(skip).limit(limit))
         return result.scalars().all()
 
     async def create(self, obj: ModelT) -> ModelT:

--- a/backend/app/infrastructure/persistence/repositories/sleep_log_repository.py
+++ b/backend/app/infrastructure/persistence/repositories/sleep_log_repository.py
@@ -16,9 +16,7 @@ class SleepLogRepository:
     def __init__(self, db: AsyncSession):
         self.db = db
 
-    async def get_by_user(
-        self, user_id: str, limit: int = 7
-    ) -> list[SleepLog]:
+    async def get_by_user(self, user_id: str, limit: int = 7) -> list[SleepLog]:
         """user_id のログを日付降順で取得"""
         result = await self.db.execute(
             select(SleepLog)
@@ -71,9 +69,7 @@ class SleepLogRepository:
         await self.db.refresh(row)
         return row
 
-    async def update_mood(
-        self, log_id: str, user_id: str, mood: int
-    ) -> SleepLog | None:
+    async def update_mood(self, log_id: str, user_id: str, mood: int) -> SleepLog | None:
         """指定ログの気分を更新"""
         row = await self.get_by_id(log_id, user_id)
         if row is None:

--- a/backend/app/infrastructure/persistence/repositories/sleep_plan_cache_repository.py
+++ b/backend/app/infrastructure/persistence/repositories/sleep_plan_cache_repository.py
@@ -33,9 +33,7 @@ class SleepPlanCacheRepository:
         )
         return result.scalar_one_or_none()
 
-    async def upsert(
-        self, user_id: str, signature_hash: str, plan_json: str
-    ) -> SleepPlanCache:
+    async def upsert(self, user_id: str, signature_hash: str, plan_json: str) -> SleepPlanCache:
         """同一 user_id の行を上書き（なければ INSERT）"""
         row = await self.get_by_user_id(user_id)
         if row:

--- a/backend/app/infrastructure/persistence/repositories/user_repository.py
+++ b/backend/app/infrastructure/persistence/repositories/user_repository.py
@@ -17,9 +17,7 @@ class UserRepository(BaseRepository[User]):
 
     async def get_by_email(self, email: str) -> User | None:
         """メールアドレスでユーザーを取得"""
-        result = await self.db.execute(
-            select(User).where(User.email == email)
-        )
+        result = await self.db.execute(select(User).where(User.email == email))
         return result.scalar_one_or_none()
 
     async def exists_by_email(self, email: str) -> bool:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,10 +7,11 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+import app.infrastructure.persistence.models  # noqa: F401 - metadata 登録
 from app.config import settings
 from app.database import init_db
-import app.infrastructure.persistence.models  # noqa: F401 - metadata 登録
-from app.presentation.api import health, plan, settings as settings_api, sleep_logs, users
+from app.presentation.api import health, plan, sleep_logs, users
+from app.presentation.api import settings as settings_api
 
 
 @asynccontextmanager
@@ -22,7 +23,7 @@ async def lifespan(app: FastAPI):
     print("👋 Shutting down SleepSupportApp API")
 
 
-app = FastAPI(
+web_app = FastAPI(
     title="SleepSupportApp API",
     description="睡眠サポートアプリのバックエンドAPI",
     version="0.1.0",
@@ -33,7 +34,7 @@ app = FastAPI(
 
 _cors_origins = ["*"] if settings.ENV == "development" else settings.CORS_ORIGINS
 _cors_credentials = settings.ENV != "development"
-app.add_middleware(
+web_app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
     allow_credentials=_cors_credentials,
@@ -41,14 +42,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(health.router, prefix=settings.API_PREFIX, tags=["health"])
-app.include_router(users.router, prefix=settings.API_PREFIX)
-app.include_router(plan.router, prefix=settings.API_PREFIX)
-app.include_router(settings_api.router, prefix=settings.API_PREFIX)
-app.include_router(sleep_logs.router, prefix=settings.API_PREFIX)
+web_app.include_router(health.router, prefix=settings.API_PREFIX, tags=["health"])
+web_app.include_router(users.router, prefix=settings.API_PREFIX)
+web_app.include_router(plan.router, prefix=settings.API_PREFIX)
+web_app.include_router(settings_api.router, prefix=settings.API_PREFIX)
+web_app.include_router(sleep_logs.router, prefix=settings.API_PREFIX)
 
 
-@app.get("/")
+@web_app.get("/")
 async def root():
     """ルートエンドポイント"""
     return {

--- a/backend/app/presentation/api/settings.py
+++ b/backend/app/presentation/api/settings.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.application.settings import GetSettingsUseCase, PutSettingsUseCase
-from app.infrastructure.persistence.database import get_db
 from app.application.settings.put_settings import PutSettingsPayload, TodayOverrideInput
+from app.infrastructure.persistence.database import get_db
 from app.infrastructure.persistence.repositories.sleep_settings_repository import (
     SleepSettingsRepository,
 )

--- a/backend/app/presentation/schemas/plan.py
+++ b/backend/app/presentation/schemas/plan.py
@@ -21,12 +21,8 @@ class PlanRequest(BaseModel):
     calendar_events: list[dict[str, Any]] = Field(
         default_factory=list, description="カレンダー予定のリスト"
     )
-    sleep_logs: list[dict[str, Any]] = Field(
-        default_factory=list, description="睡眠ログのリスト"
-    )
-    settings: dict[str, Any] = Field(
-        default_factory=dict, description="睡眠関連設定"
-    )
+    sleep_logs: list[dict[str, Any]] = Field(default_factory=list, description="睡眠ログのリスト")
+    settings: dict[str, Any] = Field(default_factory=dict, description="睡眠関連設定")
     today_override: TodayOverride | None = Field(
         default=None, description="今日だけの就寝・起床オーバーライド（null 可）"
     )

--- a/backend/app/presentation/schemas/user.py
+++ b/backend/app/presentation/schemas/user.py
@@ -7,17 +7,20 @@ from pydantic import BaseModel, EmailStr
 
 class UserCreate(BaseModel):
     """ユーザー作成リクエスト"""
+
     email: EmailStr
     name: str
 
 
 class UserUpdate(BaseModel):
     """ユーザー更新リクエスト"""
+
     name: str | None = None
 
 
 class UserResponse(BaseModel):
     """ユーザーレスポンス"""
+
     id: str
     email: str
     name: str
@@ -29,5 +32,6 @@ class UserResponse(BaseModel):
 
 class UserListResponse(BaseModel):
     """ユーザー一覧レスポンス"""
+
     users: list[UserResponse]
     total: int

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -29,5 +29,34 @@ dependencies = [
 dev = [
     "pytest>=7.0.0,<8",
     "pytest-asyncio>=0.23.0",
+    "ruff>=0.8.0",
+    "mypy>=1.13.0",
 ]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+exclude = ["alembic/versions", ".venv"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]
+ignore = [
+    "E501",
+    "B008",   # FastAPI Depends() のデフォルト引数は慣用
+    "B028",   # warnings.warn stacklevel（テストでは許容）
+    "N815",   # Pydantic スキーマの API 契約で camelCase を使用
+    "B904",   # raise from（段階的に修正予定）
+    "B010",   # setattr 定数（既存コード）
+]
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+exclude = ["alembic/versions", "tests"]
+
+[[tool.mypy.overrides]]
+module = ["tests.*"]
+ignore_errors = true
 

--- a/backend/tests/test_plan_api.py
+++ b/backend/tests/test_plan_api.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import AsyncClient
 
-from app.main import app
+from app.main import web_app as app
 from app.presentation.api.plan import get_plan_generator
 from app.presentation.dependencies.auth import get_current_user_id
 
@@ -16,9 +16,7 @@ from app.presentation.dependencies.auth import get_current_user_id
 class TestPlanAPIAuth:
     """認証ミドルウェアの挙動（401）"""
 
-    async def test_plan_returns_401_without_authorization(
-        self, client: AsyncClient
-    ):
+    async def test_plan_returns_401_without_authorization(self, client: AsyncClient):
         """Authorization ヘッダーなしで POST /sleep-plans すると 401"""
         # このテストだけ認証オーバーライドを外す
         app.dependency_overrides.pop(get_current_user_id, None)
@@ -33,8 +31,8 @@ class TestPlanAPIAuth:
             )
             assert res.status_code == 401
         finally:
-            app.dependency_overrides[get_current_user_id] = (
-                lambda: "11111111-1111-1111-1111-111111111111"
+            app.dependency_overrides[get_current_user_id] = lambda: (
+                "11111111-1111-1111-1111-111111111111"
             )
 
 
@@ -45,8 +43,18 @@ class TestPlanAPI:
     def mock_llm_plan(self):
         return {
             "week_plan": [
-                {"day": "月曜", "recommended_bedtime": "22:00", "recommended_wakeup": "06:30", "advice": "テスト"},
-                {"day": "火曜", "recommended_bedtime": "22:00", "recommended_wakeup": "06:30", "advice": "テスト"},
+                {
+                    "day": "月曜",
+                    "recommended_bedtime": "22:00",
+                    "recommended_wakeup": "06:30",
+                    "advice": "テスト",
+                },
+                {
+                    "day": "火曜",
+                    "recommended_bedtime": "22:00",
+                    "recommended_wakeup": "06:30",
+                    "advice": "テスト",
+                },
             ]
         }
 

--- a/backend/tests/test_plan_cache_repository.py
+++ b/backend/tests/test_plan_cache_repository.py
@@ -33,9 +33,7 @@ class TestSleepPlanCacheRepository:
         await db_session.flush()
         return uid
 
-    async def test_upsert_creates_then_updates(
-        self, repo: SleepPlanCacheRepository, user_id: str
-    ):
+    async def test_upsert_creates_then_updates(self, repo: SleepPlanCacheRepository, user_id: str):
         """初回 upsert で INSERT、同 user_id で再度 upsert で UPDATE になる"""
         plan_v1 = '{"week_plan": [{"day": "月曜", "advice": "v1"}]}'
         row1 = await repo.upsert(

--- a/backend/tests/test_plan_usecase.py
+++ b/backend/tests/test_plan_usecase.py
@@ -71,9 +71,7 @@ class TestGetOrCreatePlanUseCase:
         assert kwargs["signature_hash"]
         assert '"week_plan"' in kwargs["plan_json"]
 
-    async def test_force_skips_cache(
-        self, mock_cache_repo, mock_plan_generator
-    ):
+    async def test_force_skips_cache(self, mock_cache_repo, mock_plan_generator):
         """force=True の場合はキャッシュを検索せず LLM を呼ぶ"""
         llm_plan = {"week_plan": [{"day": "月曜", "advice": "強制再生成"}]}
         mock_plan_generator.generate_week_plan = AsyncMock(return_value=llm_plan)
@@ -95,9 +93,7 @@ class TestGetOrCreatePlanUseCase:
         mock_cache_repo.get_by_user_and_hash.assert_not_called()
         mock_cache_repo.upsert.assert_called_once()
 
-    async def test_today_override_passed_to_generator(
-        self, mock_cache_repo, mock_plan_generator
-    ):
+    async def test_today_override_passed_to_generator(self, mock_cache_repo, mock_plan_generator):
         """todayOverride が LLM ジェネレータに渡されること"""
         mock_cache_repo.get_by_user_and_hash.return_value = None
         llm_plan = {"week_plan": [{"day": "月曜", "advice": "オーバーライド反映"}]}
@@ -124,9 +120,7 @@ class TestGetOrCreatePlanUseCase:
         call_kwargs = mock_plan_generator.generate_week_plan.call_args[1]
         assert call_kwargs["today_override"] == override
 
-    async def test_today_override_changes_signature(
-        self, mock_cache_repo, mock_plan_generator
-    ):
+    async def test_today_override_changes_signature(self, mock_cache_repo, mock_plan_generator):
         """todayOverride が異なると署名ハッシュも変わるため、キャッシュ検索のハッシュが異なる"""
         mock_cache_repo.get_by_user_and_hash.return_value = None
         llm_plan = {"week_plan": []}
@@ -135,7 +129,10 @@ class TestGetOrCreatePlanUseCase:
         usecase = GetOrCreatePlanUseCase(mock_cache_repo, mock_plan_generator)
 
         input_no_override = GetOrCreatePlanInput(
-            user_id="user-001", calendar_events=[], sleep_logs=[], settings={},
+            user_id="user-001",
+            calendar_events=[],
+            sleep_logs=[],
+            settings={},
         )
         await usecase.execute(input_no_override)
         hash_no_override = mock_cache_repo.get_by_user_and_hash.call_args[0][1]
@@ -146,8 +143,17 @@ class TestGetOrCreatePlanUseCase:
         mock_plan_generator.generate_week_plan = AsyncMock(return_value=llm_plan)
 
         input_with_override = GetOrCreatePlanInput(
-            user_id="user-001", calendar_events=[], sleep_logs=[], settings={},
-            today_override={"date": "2026-02-20", "sleepHour": 23, "sleepMinute": 0, "wakeHour": 7, "wakeMinute": 0},
+            user_id="user-001",
+            calendar_events=[],
+            sleep_logs=[],
+            settings={},
+            today_override={
+                "date": "2026-02-20",
+                "sleepHour": 23,
+                "sleepMinute": 0,
+                "wakeHour": 7,
+                "wakeMinute": 0,
+            },
         )
         await usecase.execute(input_with_override)
         hash_with_override = mock_cache_repo.get_by_user_and_hash.call_args[0][1]

--- a/backend/tests/test_settings_api.py
+++ b/backend/tests/test_settings_api.py
@@ -4,29 +4,25 @@ GET /api/v1/settings と PUT /api/v1/settings の統合テスト（認証必須�
 
 from httpx import AsyncClient
 
-from app.main import app
+from app.main import web_app as app
 from app.presentation.dependencies.auth import get_current_user_id
 
 
 class TestSettingsAPIAuth:
     """認証必須の挙動"""
 
-    async def test_get_settings_returns_401_without_authorization(
-        self, client: AsyncClient
-    ):
+    async def test_get_settings_returns_401_without_authorization(self, client: AsyncClient):
         """Authorization なしで GET /settings すると 401"""
         app.dependency_overrides.pop(get_current_user_id, None)
         try:
             res = await client.get("/api/v1/settings")
             assert res.status_code == 401
         finally:
-            app.dependency_overrides[get_current_user_id] = (
-                lambda: "11111111-1111-1111-1111-111111111111"
+            app.dependency_overrides[get_current_user_id] = lambda: (
+                "11111111-1111-1111-1111-111111111111"
             )
 
-    async def test_put_settings_returns_401_without_authorization(
-        self, client: AsyncClient
-    ):
+    async def test_put_settings_returns_401_without_authorization(self, client: AsyncClient):
         """Authorization なしで PUT /settings すると 401"""
         app.dependency_overrides.pop(get_current_user_id, None)
         try:
@@ -40,8 +36,8 @@ class TestSettingsAPIAuth:
             )
             assert res.status_code == 401
         finally:
-            app.dependency_overrides[get_current_user_id] = (
-                lambda: "11111111-1111-1111-1111-111111111111"
+            app.dependency_overrides[get_current_user_id] = lambda: (
+                "11111111-1111-1111-1111-111111111111"
             )
 
 
@@ -75,9 +71,7 @@ class TestSettingsAPICRUD:
         finally:
             app.dependency_overrides.pop(get_current_user_id, None)
 
-    async def test_put_then_get_settings(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_put_then_get_settings(self, client: AsyncClient, unique_email: str):
         """PUT で保存 → GET で同じ内容が返る"""
         create_res = await client.post(
             "/api/v1/users",
@@ -126,9 +120,7 @@ class TestSettingsAPICRUD:
         finally:
             app.dependency_overrides.pop(get_current_user_id, None)
 
-    async def test_put_then_clear_today_override(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_put_then_clear_today_override(self, client: AsyncClient, unique_email: str):
         """today_override を null にして PUT するとオーバーライドが消える"""
         create_res = await client.post(
             "/api/v1/users",

--- a/backend/tests/test_signature.py
+++ b/backend/tests/test_signature.py
@@ -2,8 +2,6 @@
 署名ハッシュ生成の単体テスト（DB 不要）
 """
 
-import pytest
-
 from app.domain.plan.value_objects import build_signature_hash
 
 
@@ -97,8 +95,20 @@ class TestBuildSignatureHash:
 
     def test_today_override_different_date_changes_hash(self):
         """todayOverride の date が違えばハッシュも違う"""
-        override1 = {"date": "2026-02-20", "sleepHour": 23, "sleepMinute": 0, "wakeHour": 7, "wakeMinute": 0}
-        override2 = {"date": "2026-02-21", "sleepHour": 23, "sleepMinute": 0, "wakeHour": 7, "wakeMinute": 0}
+        override1 = {
+            "date": "2026-02-20",
+            "sleepHour": 23,
+            "sleepMinute": 0,
+            "wakeHour": 7,
+            "wakeMinute": 0,
+        }
+        override2 = {
+            "date": "2026-02-21",
+            "sleepHour": 23,
+            "sleepMinute": 0,
+            "wakeHour": 7,
+            "wakeMinute": 0,
+        }
         h1 = build_signature_hash([], [], {}, today_override=override1)
         h2 = build_signature_hash([], [], {}, today_override=override2)
         assert h1 != h2
@@ -112,9 +122,15 @@ class TestBuildSignatureHash:
     def test_iso_datetime_normalized_same_hash(self):
         """ISO 日時のミリ秒・タイムゾーン表記が違っても同じハッシュになる（キャッシュ安定）"""
         cal1 = [{"title": "A", "start": "2026-02-18T09:00:00.000Z", "end": "2026-02-18T10:00:00Z"}]
-        cal2 = [{"title": "A", "start": "2026-02-18T09:00:00.123Z", "end": "2026-02-18T10:00:00.000Z"}]
-        logs1 = [{"date": "2026-02-17", "score": 80, "scheduled_sleep_time": "2026-02-17T23:00:00Z"}]
-        logs2 = [{"date": "2026-02-17", "score": 80, "scheduled_sleep_time": "2026-02-17T23:00:00.456Z"}]
+        cal2 = [
+            {"title": "A", "start": "2026-02-18T09:00:00.123Z", "end": "2026-02-18T10:00:00.000Z"}
+        ]
+        logs1 = [
+            {"date": "2026-02-17", "score": 80, "scheduled_sleep_time": "2026-02-17T23:00:00Z"}
+        ]
+        logs2 = [
+            {"date": "2026-02-17", "score": 80, "scheduled_sleep_time": "2026-02-17T23:00:00.456Z"}
+        ]
         h_cal1 = build_signature_hash(cal1, [], {})
         h_cal2 = build_signature_hash(cal2, [], {})
         h_logs1 = build_signature_hash([], logs1, {})

--- a/backend/tests/test_sleep_logs_api.py
+++ b/backend/tests/test_sleep_logs_api.py
@@ -18,9 +18,7 @@ async def ensure_test_user(db_session: AsyncSession):
     """TEST_USER_ID のユーザーが DB に存在することを保証する"""
     from sqlalchemy import select
 
-    result = await db_session.execute(
-        select(User).where(User.id == TEST_USER_ID)
-    )
+    result = await db_session.execute(select(User).where(User.id == TEST_USER_ID))
     if result.scalar_one_or_none() is None:
         user = User(
             id=TEST_USER_ID,

--- a/backend/tests/test_users_crud.py
+++ b/backend/tests/test_users_crud.py
@@ -8,9 +8,7 @@ from httpx import AsyncClient
 class TestUsersCRUD:
     """Users CRUD の統合テスト"""
 
-    async def test_create_and_read_user(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_create_and_read_user(self, client: AsyncClient, unique_email: str):
         """Create → Read の流れ"""
         # Create
         create_res = await client.post(
@@ -36,9 +34,7 @@ class TestUsersCRUD:
         users = list_res.json()["users"]
         assert any(u["id"] == user_id for u in users)
 
-    async def test_create_duplicate_email_fails(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_create_duplicate_email_fails(self, client: AsyncClient, unique_email: str):
         """同じメールで作成すると409"""
         payload = {"email": unique_email, "name": "ユーザー1"}
         res1 = await client.post("/api/v1/users", json=payload)
@@ -47,9 +43,7 @@ class TestUsersCRUD:
         res2 = await client.post("/api/v1/users", json=payload)
         assert res2.status_code == 409
 
-    async def test_update_user(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_update_user(self, client: AsyncClient, unique_email: str):
         """Create → Update → Read"""
         # Create
         create_res = await client.post(
@@ -72,9 +66,7 @@ class TestUsersCRUD:
         assert get_res.status_code == 200
         assert get_res.json()["name"] == "新名前"
 
-    async def test_delete_user(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_delete_user(self, client: AsyncClient, unique_email: str):
         """Create → Delete → Read 404"""
         # Create
         create_res = await client.post(
@@ -97,9 +89,7 @@ class TestUsersCRUD:
         res = await client.get("/api/v1/users/00000000-0000-0000-0000-000000000000")
         assert res.status_code == 404
 
-    async def test_full_crud_flow(
-        self, client: AsyncClient, unique_email: str
-    ):
+    async def test_full_crud_flow(self, client: AsyncClient, unique_email: str):
         """Create → Read → Update → Read → Delete → 404 の一連の流れ"""
         # Create
         create_res = await client.post(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -574,6 +574,79 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/01/0e748af5e4fee180cf7cd12bd12b0513ad23b045dccb2a83191bde82d168/librt-0.8.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:681dc2451d6d846794a828c16c22dc452d924e9f700a485b7ecb887a30aad1fd", size = 65315, upload-time = "2026-02-17T16:11:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/4d/7184806efda571887c798d573ca4134c80ac8642dcdd32f12c31b939c595/librt-0.8.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b4350b13cc0e6f5bec8fa7caf29a8fb8cdc051a3bae45cfbfd7ce64f009965", size = 68021, upload-time = "2026-02-17T16:11:26.129Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/88/c3c52d2a5d5101f28d3dc89298444626e7874aa904eed498464c2af17627/librt-0.8.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ac1e7817fd0ed3d14fd7c5df91daed84c48e4c2a11ee99c0547f9f62fdae13da", size = 194500, upload-time = "2026-02-17T16:11:27.177Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5d/6fb0a25b6a8906e85b2c3b87bee1d6ed31510be7605b06772f9374ca5cb3/librt-0.8.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:747328be0c5b7075cde86a0e09d7a9196029800ba75a1689332348e998fb85c0", size = 205622, upload-time = "2026-02-17T16:11:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/8006ae81227105476a45691f5831499e4d936b1c049b0c1feb17c11b02d1/librt-0.8.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0af2bd2bc204fa27f3d6711d0f360e6b8c684a035206257a81673ab924aa11e", size = 218304, upload-time = "2026-02-17T16:11:29.344Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/19/60e07886ad16670aae57ef44dada41912c90906a6fe9f2b9abac21374748/librt-0.8.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d480de377f5b687b6b1bc0c0407426da556e2a757633cc7e4d2e1a057aa688f3", size = 211493, upload-time = "2026-02-17T16:11:30.445Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/cf/f666c89d0e861d05600438213feeb818c7514d3315bae3648b1fc145d2b6/librt-0.8.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d0ee06b5b5291f609ddb37b9750985b27bc567791bc87c76a569b3feed8481ac", size = 219129, upload-time = "2026-02-17T16:11:32.021Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ef/f1bea01e40b4a879364c031476c82a0dc69ce068daad67ab96302fed2d45/librt-0.8.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9e2c6f77b9ad48ce5603b83b7da9ee3e36b3ab425353f695cba13200c5d96596", size = 213113, upload-time = "2026-02-17T16:11:33.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/80/cdab544370cc6bc1b72ea369525f547a59e6938ef6863a11ab3cd24759af/librt-0.8.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:439352ba9373f11cb8e1933da194dcc6206daf779ff8df0ed69c5e39113e6a99", size = 212269, upload-time = "2026-02-17T16:11:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9c/48d6ed8dac595654f15eceab2035131c136d1ae9a1e3548e777bb6dbb95d/librt-0.8.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:82210adabbc331dbb65d7868b105185464ef13f56f7f76688565ad79f648b0fe", size = 234673, upload-time = "2026-02-17T16:11:36.063Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/35b68b1db517f27a01be4467593292eb5315def8900afad29fabf56304ba/librt-0.8.1-cp311-cp311-win32.whl", hash = "sha256:52c224e14614b750c0a6d97368e16804a98c684657c7518752c356834fff83bb", size = 54597, upload-time = "2026-02-17T16:11:37.544Z" },
+    { url = "https://files.pythonhosted.org/packages/71/02/796fe8f02822235966693f257bf2c79f40e11337337a657a8cfebba5febc/librt-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:c00e5c884f528c9932d278d5c9cbbea38a6b81eb62c02e06ae53751a83a4d52b", size = 61733, upload-time = "2026-02-17T16:11:38.691Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/232e13d61f879a42a4e7117d65e4984bb28371a34bb6fb9ca54ec2c8f54e/librt-0.8.1-cp311-cp311-win_arm64.whl", hash = "sha256:f7cdf7f26c2286ffb02e46d7bac56c94655540b26347673bea15fa52a6af17e9", size = 52273, upload-time = "2026-02-17T16:11:40.308Z" },
+    { url = "https://files.pythonhosted.org/packages/95/21/d39b0a87ac52fc98f621fb6f8060efb017a767ebbbac2f99fbcbc9ddc0d7/librt-0.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a28f2612ab566b17f3698b0da021ff9960610301607c9a5e8eaca62f5e1c350a", size = 66516, upload-time = "2026-02-17T16:11:41.604Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f1/46375e71441c43e8ae335905e069f1c54febee63a146278bcee8782c84fd/librt-0.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:60a78b694c9aee2a0f1aaeaa7d101cf713e92e8423a941d2897f4fa37908dab9", size = 68634, upload-time = "2026-02-17T16:11:43.268Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/c510de7f93bf1fa19e13423a606d8189a02624a800710f6e6a0a0f0784b3/librt-0.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:758509ea3f1eba2a57558e7e98f4659d0ea7670bff49673b0dde18a3c7e6c0eb", size = 198941, upload-time = "2026-02-17T16:11:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/e725903416409a533d92398e88ce665476f275081d0d7d42f9c4951999e5/librt-0.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:039b9f2c506bd0ab0f8725aa5ba339c6f0cd19d3b514b50d134789809c24285d", size = 209991, upload-time = "2026-02-17T16:11:45.462Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7a/8d908a152e1875c9f8eac96c97a480df425e657cdb47854b9efaa4998889/librt-0.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bb54f1205a3a6ab41a6fd71dfcdcbd278670d3a90ca502a30d9da583105b6f7", size = 224476, upload-time = "2026-02-17T16:11:46.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/a22c34f2c485b8903a06f3fe3315341fe6876ef3599792344669db98fcff/librt-0.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:05bd41cdee35b0c59c259f870f6da532a2c5ca57db95b5f23689fcb5c9e42440", size = 217518, upload-time = "2026-02-17T16:11:47.746Z" },
+    { url = "https://files.pythonhosted.org/packages/79/6f/5c6fea00357e4f82ba44f81dbfb027921f1ab10e320d4a64e1c408d035d9/librt-0.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adfab487facf03f0d0857b8710cf82d0704a309d8ffc33b03d9302b4c64e91a9", size = 225116, upload-time = "2026-02-17T16:11:49.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a0/95ced4e7b1267fe1e2720a111685bcddf0e781f7e9e0ce59d751c44dcfe5/librt-0.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:153188fe98a72f206042be10a2c6026139852805215ed9539186312d50a8e972", size = 217751, upload-time = "2026-02-17T16:11:50.49Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c2/0517281cb4d4101c27ab59472924e67f55e375bc46bedae94ac6dc6e1902/librt-0.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:dd3c41254ee98604b08bd5b3af5bf0a89740d4ee0711de95b65166bf44091921", size = 218378, upload-time = "2026-02-17T16:11:51.783Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e8/37b3ac108e8976888e559a7b227d0ceac03c384cfd3e7a1c2ee248dbae79/librt-0.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e0d138c7ae532908cbb342162b2611dbd4d90c941cd25ab82084aaf71d2c0bd0", size = 241199, upload-time = "2026-02-17T16:11:53.561Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/35812d041c53967fedf551a39399271bbe4257e681236a2cf1a69c8e7fa1/librt-0.8.1-cp312-cp312-win32.whl", hash = "sha256:43353b943613c5d9c49a25aaffdba46f888ec354e71e3529a00cca3f04d66a7a", size = 54917, upload-time = "2026-02-17T16:11:54.758Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d1/fa5d5331b862b9775aaf2a100f5ef86854e5d4407f71bddf102f4421e034/librt-0.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:ff8baf1f8d3f4b6b7257fcb75a501f2a5499d0dda57645baa09d4d0d34b19444", size = 62017, upload-time = "2026-02-17T16:11:55.748Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7c/c614252f9acda59b01a66e2ddfd243ed1c7e1deab0293332dfbccf862808/librt-0.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f2ae3725904f7377e11cc37722d5d401e8b3d5851fb9273d7f4fe04f6b3d37d", size = 52441, upload-time = "2026-02-17T16:11:56.801Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -894,12 +967,69 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/47/6b3ebabd5474d9cdc170d1342fbf9dddc1b0ec13ec90bf9004ee6f391c31/mypy-1.19.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d8dfc6ab58ca7dda47d9237349157500468e404b17213d44fc1cb77bce532288", size = 13028539, upload-time = "2025-12-15T05:03:44.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a6/ac7c7a88a3c9c54334f53a941b765e6ec6c4ebd65d3fe8cdcfbe0d0fd7db/mypy-1.19.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e3f276d8493c3c97930e354b2595a44a21348b320d859fb4a2b9f66da9ed27ab", size = 12083163, upload-time = "2025-12-15T05:03:37.679Z" },
+    { url = "https://files.pythonhosted.org/packages/67/af/3afa9cf880aa4a2c803798ac24f1d11ef72a0c8079689fac5cfd815e2830/mypy-1.19.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2abb24cf3f17864770d18d673c85235ba52456b36a06b6afc1e07c1fdcd3d0e6", size = 12687629, upload-time = "2025-12-15T05:02:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/46/20f8a7114a56484ab268b0ab372461cb3a8f7deed31ea96b83a4e4cfcfca/mypy-1.19.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a009ffa5a621762d0c926a078c2d639104becab69e79538a494bcccb62cc0331", size = 13436933, upload-time = "2025-12-15T05:03:15.606Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f8/33b291ea85050a21f15da910002460f1f445f8007adb29230f0adea279cb/mypy-1.19.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f7cee03c9a2e2ee26ec07479f38ea9c884e301d42c6d43a19d20fb014e3ba925", size = 13661754, upload-time = "2025-12-15T05:02:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a3/47cbd4e85bec4335a9cd80cf67dbc02be21b5d4c9c23ad6b95d6c5196bac/mypy-1.19.1-cp311-cp311-win_amd64.whl", hash = "sha256:4b84a7a18f41e167f7995200a1d07a4a6810e89d29859df936f1c3923d263042", size = 10055772, upload-time = "2025-12-15T05:03:26.179Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/19bfae96f6615aa8a0604915512e0289b1fad33d5909bf7244f02935d33a/mypy-1.19.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8174a03289288c1f6c46d55cef02379b478bfbc8e358e02047487cad44c6ca1", size = 13206053, upload-time = "2025-12-15T05:03:46.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/34/3e63879ab041602154ba2a9f99817bb0c85c4df19a23a1443c8986e4d565/mypy-1.19.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffcebe56eb09ff0c0885e750036a095e23793ba6c2e894e7e63f6d89ad51f22e", size = 12219134, upload-time = "2025-12-15T05:03:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/2db6f0e95366b630364e09845672dbee0cbf0bbe753a204b29a944967cd9/mypy-1.19.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b64d987153888790bcdb03a6473d321820597ab8dd9243b27a92153c4fa50fd2", size = 12731616, upload-time = "2025-12-15T05:02:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/00/be/dd56c1fd4807bc1eba1cf18b2a850d0de7bacb55e158755eb79f77c41f8e/mypy-1.19.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c35d298c2c4bba75feb2195655dfea8124d855dfd7343bf8b8c055421eaf0cf8", size = 13620847, upload-time = "2025-12-15T05:03:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/332951aae42b79329f743bf1da088cd75d8d4d9acc18fbcbd84f26c1af4e/mypy-1.19.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:34c81968774648ab5ac09c29a375fdede03ba253f8f8287847bd480782f73a6a", size = 13834976, upload-time = "2025-12-15T05:03:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/63/e7493e5f90e1e085c562bb06e2eb32cae27c5057b9653348d38b47daaecc/mypy-1.19.1-cp312-cp312-win_amd64.whl", hash = "sha256:b10e7c2cd7870ba4ad9b2d8a6102eb5ffc1f16ca35e3de6bfa390c1113029d13", size = 10118104, upload-time = "2025-12-15T05:03:10.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]
@@ -1483,6 +1613,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
+    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
+    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
+    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
+    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1514,8 +1669,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1526,6 +1683,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.109.2" },
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "httpx", specifier = ">=0.26" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.6.1" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
@@ -1533,6 +1691,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0,<8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sqlalchemy", specifier = ">=2.0.25" },
     { name = "supabase", specifier = ">=2.9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.1" },

--- a/scripts/wait-for-db.mjs
+++ b/scripts/wait-for-db.mjs
@@ -41,7 +41,9 @@ function sleep() {
 const DB_CONTAINER_NAME = 'sleepsupport-db';
 
 console.log('DB 起動待機...');
-const out = run('docker-compose ps -q db');
+// Docker Compose V2 (docker compose) を優先、無ければ V1 (docker-compose)
+const composeCmd = run('docker compose version') ? 'docker compose' : 'docker-compose';
+const out = run(composeCmd + ' ps -q db');
 const idFromCompose = out ? out.split(/\r?\n/)[0].trim().replace(/\s/g, '') : '';
 if (!idFromCompose) {
   console.error('DB コンテナが見つかりません（docker compose ps -q db が空です）');


### PR DESCRIPTION
## 概要
CI の改善として以下を実装しました。

## 変更内容

### 1. フロントの「ビルド」を名実どおりに
- Frontend ジョブに `npx expo export --platform web` を追加
- 型チェック・Lint・フォーマットに加え、実ビルドが通ることを CI で確認

### 2. DB 待機を wait-for-db.mjs に統一
- Backend ジョブの `sleep 5` を廃止し、`node scripts/wait-for-db.mjs` で DB 起動を待機
- `scripts/wait-for-db.mjs` を Docker Compose V2 (`docker compose`) と V1 (`docker-compose`) の両方で動作するよう修正

### 3. バックエンドに Lint と型チェックを追加
- `backend/pyproject.toml` に **ruff** と **mypy** を dev 依存として追加
- CI で `ruff check` / `ruff format --check` を実行（必須）
- CI で `mypy app` を実行（現状は `continue-on-error: true`、型エラー解消後に外す想定）
- uv の `cache: "pip"` を有効化
- `app.main`: mypy の名前衝突を避けるため FastAPI インスタンスを `web_app` に変更
  - Dockerfile / IMPLEMENT_README / テストの import を `web_app` に更新
- ruff の自動修正・format 適用、型注釈・conftest の軽微な修正

## 注意
- バックエンド起動は `uvicorn app.main:web_app` に変更済みです
- mypy は現状 continue-on-error のため、型エラー解消後に `continue-on-error` を外すとよいです

Made with [Cursor](https://cursor.com)